### PR TITLE
Support for MSYS2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Clipboard
 
-Zsh clipboard plugin who adds cross-platform helper functions to access the system clipboard. Works on macOS, X11 (and Wayland) and Cygwin
+Zsh clipboard plugin that adds cross-platform helper functions to access the system clipboard. Works on macOS, X11 (and Wayland), Cygwin, MSYS2, and Git for Windows.
 
 
-1. pbcopy - pipe to this function something `echo Hello world | pbcopy` and this will be copied to system clipboard. 
-2. pbcopy - show content of system clipboard `pbpaste | grep Hello`. 
-3. clip - a wrapper around 2 previous functions, if you didn't pipe to it something function will show clipboard content otherwise will copy to clipboard.
+1. `pbcopy` - pipe something to this function, e.g. `echo Hello world | pbcopy`, and it will be copied to system clipboard. 
+2. `pbpaste` - show the contents of the system clipboard, e.g. `pbpaste | grep Hello`. 
+3. `clip` - a wrapper around the two previous functions. If you do not pipe something to it, the function will show the clipboard contents; otherwise, it will copy something to the clipboard.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clipboard
 
-Zsh clipboard plugin that adds cross-platform helper functions to access the system clipboard. Works on macOS, X11 (and Wayland), Cygwin, MSYS2, and Git for Windows.
+Zsh clipboard plugin that adds cross-platform helper functions to access the system clipboard. Works on macOS, X11 (and Wayland), Cygwin, and MSYS2.
 
 
 1. `pbcopy` - pipe something to this function, e.g. `echo Hello world | pbcopy`, and it will be copied to system clipboard. 

--- a/clipboard.plugin.zsh
+++ b/clipboard.plugin.zsh
@@ -12,9 +12,14 @@ if [[ "$OSTYPE" == darwin* ]]; then
         pbpaste
     fi
   }
-elif [[ "$OSTYPE" == cygwin* ]]; then
-  alias open='cygstart'
-  alias o='cygstart'
+elif [[ "$OSTYPE" == (cygwin*|msys) ]]; then
+  if [[ $OSTYPE == cygwin* ]]; then
+    alias open='cygstart'
+    alias o='cygstart'
+  else
+    alias open='start'
+    alias o='start'
+  fi
   alias pbcopy='tee > /dev/clipboard'
   alias pbpaste='cat /dev/clipboard'
   function clip(){

--- a/clipboard.plugin.zsh
+++ b/clipboard.plugin.zsh
@@ -17,8 +17,8 @@ elif [[ "$OSTYPE" == (cygwin*|msys) ]]; then
     alias open='cygstart'
     alias o='cygstart'
   else
-    alias open='start'
-    alias o='start'
+    alias open='explorer'
+    alias o='explorer'
   fi
   alias pbcopy='tee > /dev/clipboard'
   alias pbpaste='cat /dev/clipboard'


### PR DESCRIPTION
What a great plugin!

It can easily be made to work with MSYS2, which uses the same `/dev/clipboard` technique of accessing the system clipboard. MSYS2 has a program that is a little bit like `cygstart` (`start`), but it does not work very well. You may, however, get very good results by just using `explorer.exe` -- it will open files with their default applications.