### PR TITLE
Support for Linux distros running in WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clipboard
 
-Zsh clipboard plugin that adds cross-platform helper functions to access the system clipboard. Works on macOS, X11 (and Wayland), Cygwin, MSYS2, and WSL. WSL distros will use the native Windows system clipboard when in a terminal; they will use the Linux GUI system clipboard when it is available.
+Zsh clipboard plugin that adds cross-platform helper functions to access the system clipboard. Works on macOS, X11 (and Wayland), Cygwin, MSYS2, and WSL.
 
 
 1. `pbcopy` - pipe something to this function, e.g. `echo Hello world | pbcopy`, and it will be copied to system clipboard. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clipboard
 
-Zsh clipboard plugin that adds cross-platform helper functions to access the system clipboard. Works on macOS, X11 (and Wayland), Cygwin, and MSYS2.
+Zsh clipboard plugin that adds cross-platform helper functions to access the system clipboard. Works on macOS, X11 (and Wayland), Cygwin, MSYS2, and WSL. WSL distros will use the native Windows system clipboard when in a terminal; they will use the Linux GUI system clipboard when it is available.
 
 
 1. `pbcopy` - pipe something to this function, e.g. `echo Hello world | pbcopy`, and it will be copied to system clipboard. 

--- a/clipboard.plugin.zsh
+++ b/clipboard.plugin.zsh
@@ -29,6 +29,20 @@ elif [[ "$OSTYPE" == (cygwin*|msys) ]]; then
       cat /dev/clipboard
     fi
   }
+# WSL without a GUI
+elif [[ $OSTYPE == linux* ]] && [[ $(< /proc/version) == *Microsoft* ]] \
+  && ! xclip -o &> /dev/null; then
+  alias open='explorer.exe'
+  alias o='explorer.exe'
+  alias pbcopy='clip.exe'
+  alias pbpaste='powershell.exe -Command Get-Clipboard'
+  function clip() {
+    if [[ ! -t 0   ]]; then
+      clip.exe
+    else
+      powershell.exe -Command Get-Clipboard
+    fi
+  }
 else
   alias open='xdg-open'
   alias o='xdg-open'

--- a/clipboard.plugin.zsh
+++ b/clipboard.plugin.zsh
@@ -29,7 +29,7 @@ elif [[ "$OSTYPE" == (cygwin*|msys) ]]; then
       cat /dev/clipboard
     fi
   }
-# WSL without a GUI
+# WSL
 elif [[ $OSTYPE == linux* ]] && [[ $(< /proc/version) == *Microsoft* ]] \
   && ! xclip -o &> /dev/null; then
   alias open='explorer.exe'


### PR DESCRIPTION
WSL distros can access the Windows system clipboard using `clip.exe` and `powershell.exe -Command Get-Clipboard` (the latter is a little slow).