### PR TITLE
Various improvements, both general and for Windows (WSL/Cygwin/MSYS2)

### DIFF
--- a/functions/clip
+++ b/functions/clip
@@ -1,29 +1,7 @@
 #!/usr/bin/env zsh
 
 if [[ -t 0 ]]; then
-  if (( $+commands[xclip] )); then
-    xclip -selection clipboard -out
-  elif (( $+commands[xsel] )); then
-    xsel -b
-  elif [[ "$OSTYPE" == darwin* ]]; then
-    command pbpaste
-  elif [[ "$OSTYPE" == (cygwin*|msys) ]]; then
-    cat /dev/clipboard
-  elif [[ $OSTYPE == linux* ]] && [[ -r /proc/version ]] && [[ $(< /proc/version) == *microsoft* ]]; then
-    # WSL
-    powershell.exe -Command Get-Clipboard
-  fi
+  pbpaste
 else
-  if (( $+commands[xclip] )); then
-    xclip -selection clipboard -in
-  elif (( $+commands[xsel] )); then
-    xsel -b
-  elif [[ "$OSTYPE" == darwin* ]]; then
-    command pbcopy
-  elif [[ "$OSTYPE" == (cygwin*|msys) ]]; then
-    tee > /dev/clipboard
-  elif [[ $OSTYPE == linux* ]] && [[ -r /proc/version ]] && [[ $(< /proc/version) == *microsoft* ]]; then
-    # WSL
-    clip.exe
-  fi
+  pbcopy
 fi

--- a/functions/open
+++ b/functions/open
@@ -1,14 +1,15 @@
 #!/usr/bin/env zsh
 
-if (( $+commands[xdg-open] )); then
-  xdg-open $@
-elif [[ "$OSTYPE" == darwin* ]]; then
-  command open $@
-elif [[ "$OSTYPE" == cygwin* ]]; then
-  cygstart $@
-elif [[ "$OSTYPE" == msys ]]; then
-  explorer $@
-elif [[ $OSTYPE == linux* ]] && [[ -r /proc/version ]] && [[ $(< /proc/version) == *microsoft* ]]; then
-  # WSL
+# WSL 1 or 2
+if [[ $OSTYPE == linux* && -r /proc/version &&
+    $(< /proc/version) == *[Mm]icrosoft* ]]; then
   explorer.exe $@
+elif (( ${+commands[xdg-open]} )); then
+  xdg-open $@
+elif [[ $OSTYPE == darwin* ]]; then
+  command open $@
+elif [[ $OSTYPE == cygwin* ]]; then
+  cygstart $@
+elif [[ $OSTYPE == msys ]]; then
+  explorer.exe $(cygpath -w $@)
 fi

--- a/functions/pbcopy
+++ b/functions/pbcopy
@@ -1,14 +1,17 @@
 #!/usr/bin/env zsh
 
-if (( $+commands[xclip] )); then
+# WSL 1 or 2
+if [[ $OSTYPE == linux* && -r /proc/version &&
+    $(< /proc/version) == *[Mm]icrosoft* ]]; then
+  if ! xclip -selection clipboard -in 2> /dev/null; then
+    clip.exe
+  fi
+elif (( ${+commands[xclip]} )); then
   xclip -selection clipboard -in
-elif (( $+commands[xsel] )); then
+elif (( ${+commands[xsel]} )); then
   xsel -b
-elif [[ "$OSTYPE" == darwin* ]]; then
+elif [[ $OSTYPE == darwin* ]]; then
   command pbcopy
-elif [[ "$OSTYPE" == (cygwin*|msys) ]]; then
+elif [[ $OSTYPE == (cygwin*|msys) ]]; then
   tee > /dev/clipboard
-elif [[ $OSTYPE == linux* ]] && [[ -r /proc/version ]] && [[ $(< /proc/version) == *microsoft* ]]; then
-  # WSL
-  clip.exe
 fi

--- a/functions/pbpaste
+++ b/functions/pbpaste
@@ -1,14 +1,17 @@
 #!/usr/bin/env zsh
 
-if (( $+commands[xclip] )); then
+# WSL 1 or 2
+if [[ $OSTYPE == linux* && -r /proc/version &&
+    $(< /proc/version) == *[Mm]icrosoft* ]]; then
+  if ! xclip -selection clipboard -out 2> /dev/null; then
+    powershell.exe -NoProfile -NonInteractive -Command Get-Clipboard
+  fi
+elif (( ${+commands[xclip]} )); then
   xclip -selection clipboard -out
-elif (( $+commands[xsel] )); then
+elif (( ${+commands[xsel]} )); then
   xsel -b
-elif [[ "$OSTYPE" == darwin* ]]; then
+elif [[ $OSTYPE == darwin* ]]; then
   command pbpaste
-elif [[ "$OSTYPE" == (cygwin*|msys) ]]; then
-  cat /dev/clipboard
-elif [[ $OSTYPE == linux* ]] && [[ -r /proc/version ]] && [[ $(< /proc/version) == *microsoft* ]]; then
-  # WSL
-  powershell.exe -Command Get-Clipboard
+elif [[ $OSTYPE == (cygwin*|msys) ]]; then
+  print "$(< /dev/clipboard)"
 fi


### PR DESCRIPTION
+ General
    - `clip` can just invoke `pbcopy` and `pbpaste`; the code is easier to maintain that way.
    - It is good to use curly brackets with arrays (e.g., `${+commands[xdg-open]}`, not `$+commands[xdg-open]`); that way, if the user is using the `KSH_ARRAYS` option, the utilities will still work.
    - I removed unnecessary double quotes inside double brackets.
    - I fixed a few things in the documentation (especially references to "zshmarks" which should have been "zpm-zsh/clipboard").
+ WSL
    - While pull request [#5](https://github.com/zpm-zsh/clipboard/pull/5) correctly updated the code to detect WSL2, there will probably always be people who use WSL1 (I use both). `/proc/version` for WSL2 contains the string `microsoft`, while in WSL1 it is still `Microsoft`; let us have the utilities check for `*[Mm]icrosoft*`.
    - `xclip` may be installed in WSL, but that does not necessarily mean that X is running -- if it is not, `clip`, `pbcopy`, and `pbpaste` will not work. It might be best to try using `xclip` and then fall back on Windows `clip.exe` and Powershell's `Get-Clipboard` if that fails. Powershell runs more quickly if the `-NoProfile` and `-NonInteractive` options are used. Note that when using the Windows system clipboard, CRLF gets added during the paste process.
+ Cygwin/MSYS2
     - Using `print $( < ... )` is faster than using `cat`.
+ MSYS2
    - It is important to use `cygpath` in the `open` function; otherwise Windows will not understand `open ../README.md`.